### PR TITLE
Permission Middleware Fix for Permitted Roles

### DIFF
--- a/api/v1/middleware/permission.js
+++ b/api/v1/middleware/permission.js
@@ -12,7 +12,7 @@ module.exports = function(allowed, isOwner) {
 		if (!req.auth) {
 			// there is no auth information, so the requester cannot be allowed
 			return next(new errors.UnauthorizedError());
-		} if (isOwner && !isOwner(req)) {
+		} if (isOwner && !isOwner(req) && !_.includes(allowed, req.auth.role)) {
 			// the endpoint defined a method for determining whether the
 			// requester owns the resource, but this was not true
 			return next(new errors.UnauthorizedError());

--- a/api/v1/models/Model.js
+++ b/api/v1/models/Model.js
@@ -29,7 +29,8 @@ Model.transaction = function (callback) {
  */
 Model.findById = function (id) {
 	var queryWhere = {};
-	queryWhere[this.idAttribute] = id;
+	// queryWhere[this.idAttribute] = id; // This fails -- "this" does not have idAttribute, only Model instances do
+  queryWhere['id'] = id;
 	return this.collection().query({ where: queryWhere }).fetchOne();
 };
 


### PR DESCRIPTION
Response to Issue #18. Fixed two bugs in the `findByID` functions. One error in `middleware.permission` would cause the `GET /user/{:id}` route to fail unless the requester was requesting their own user data. This fix opens it up to all admin / staff roles as well as the requester of their own data. In addition, a bug in `Model` caused all `findByID` calls to fail due to the use of an invalid attribute. 

Please let me know if I should make any changes here that would suit the project better.