### PR TITLE
Fixes EventAPI For iOS

### DIFF
--- a/api/v1/controllers/EventController.js
+++ b/api/v1/controllers/EventController.js
@@ -55,13 +55,19 @@ function getAllEvents (req, res, next) {
     services.EventService.getAllEvents()
         .then(function (result) {
             res.body = result.toJSON();
-
-            next();
             return null;
         })
+        .then(function () {
+            return _Promise.map(res.body[0].locations, function(loc) {
+                loc.id = loc.locationId;
+                return null;
+            });
+        })
+        .then(function () {
+            return next();
+        })
         .catch(function (error) {
-            next(error);
-            return null;
+            return next(error);
         });
 }
 


### PR DESCRIPTION
As the iOS app cannot be updated to correct a bug within reasonable time for the duration of HackIllinois 2017 the locationevents id field is replaced with the locationid.