### PR TITLE
fixed bug that prevented migrations from running

### DIFF
--- a/database/flyway.sh
+++ b/database/flyway.sh
@@ -11,4 +11,4 @@ if [ "$#" -ne 2 ]; then
 	exit 2
 fi
 
-flyway -user=$DB_USERNAME -password=$DB_PASSWORD  -url=jdbc:mysql://$DB_HOSTNAME:$DB_PORT/$DB_NAME -locations=filesystem:$PWD/migration -baselineOnMigrate=true -sqlMigrationSuffix=.sql $1
+flyway -user=$DB_USERNAME -password=$DB_PASSWORD  -url=jdbc:mysql://$DB_HOSTNAME:$DB_PORT/$DB_NAME "-locations=filesystem:$PWD/migration" -baselineOnMigrate=true -sqlMigrationSuffix=.sql $1

--- a/database/flyway.sh
+++ b/database/flyway.sh
@@ -11,4 +11,4 @@ if [ "$#" -ne 2 ]; then
 	exit 2
 fi
 
-flyway -user=$DB_USERNAME -password=$DB_PASSWORD  -url=jdbc:mysql://$DB_HOSTNAME:$DB_PORT/$DB_NAME "-locations=filesystem:$PWD/migration" -baselineOnMigrate=true -sqlMigrationSuffix=.sql $1
+flyway -user=$DB_USERNAME -password=$DB_PASSWORD  -url=jdbc:mysql://$DB_HOSTNAME:$DB_PORT/$DB_NAME -locations=filesystem:"$PWD/migration" -baselineOnMigrate=true -sqlMigrationSuffix=.sql $1


### PR DESCRIPTION
On some Linux systems, if the $PWD from which the migrations where run from contained a space,
e.g. `/Volumes/macOS Storage/HackIllinois/api-2017`, the script would fail because it would expect the space to be escaped as `/Volumes/macOS\ Storage/HackIllinois/api-2017-local` wrapping that part of the script seems to fix that